### PR TITLE
Fix default quads on Fabric

### DIFF
--- a/fabric/src/main/java/earth/terrarium/athena/api/client/fabric/AthenaBakedModel.java
+++ b/fabric/src/main/java/earth/terrarium/athena/api/client/fabric/AthenaBakedModel.java
@@ -1,10 +1,13 @@
 package earth.terrarium.athena.api.client.fabric;
 
 import earth.terrarium.athena.api.client.models.AthenaBlockModel;
+import earth.terrarium.athena.api.client.models.AthenaQuad;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import net.fabricmc.fabric.api.renderer.v1.RendererAccess;
 import net.fabricmc.fabric.api.renderer.v1.mesh.MutableQuadView;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
 import net.fabricmc.fabric.api.renderer.v1.model.FabricBakedModel;
+import net.fabricmc.fabric.api.renderer.v1.model.ModelHelper;
 import net.fabricmc.fabric.api.renderer.v1.render.RenderContext;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.block.model.BakedQuad;
@@ -34,6 +37,8 @@ public class AthenaBakedModel implements BakedModel, FabricBakedModel {
 
     private final AthenaBlockModel model;
     private final Int2ObjectMap<TextureAtlasSprite> textures;
+    @Nullable
+    private List<BakedQuad>[] defaultQuads = null;
 
     public AthenaBakedModel(AthenaBlockModel model, Function<Material, TextureAtlasSprite> function) {
         this.model = model;
@@ -47,44 +52,67 @@ public class AthenaBakedModel implements BakedModel, FabricBakedModel {
 
     @Override
     public void emitBlockQuads(BlockAndTintGetter blockView, BlockState state, BlockPos pos, Supplier<RandomSource> randomSupplier, RenderContext context) {
-        this.emitQuads(context.getEmitter(), blockView, state, pos);
-    }
-
-    @Override
-    public void emitItemQuads(ItemStack stack, Supplier<RandomSource> randomSupplier, RenderContext context) {
-        this.emitQuads(context.getEmitter(), null, null, null);
-    }
-
-    private void emitQuads(QuadEmitter emitter, @Nullable BlockAndTintGetter level, @Nullable BlockState state, @Nullable BlockPos pos) {
-        if (level != null && state != null && pos != null) {
-            WrappedGetter getter = new WrappedGetter(level);
-            for (Direction value : DIRECTIONS) {
-                for (var sprite : model.getQuads(getter, state, pos, value)) {
-                    TextureAtlasSprite texture = this.textures.get(sprite.sprite());
-                    if (texture == null) {
-                        continue;
-                    }
-                    emitter.square(value, sprite.left(), sprite.bottom(), sprite.right(), sprite.top(), sprite.depth());
-
-                    int flag = MutableQuadView.BAKE_LOCK_UV;
-
-                    switch (sprite.rotation()) {
-                        case CLOCKWISE_90 -> flag |= MutableQuadView.BAKE_ROTATE_90;
-                        case CLOCKWISE_180 -> flag |= MutableQuadView.BAKE_ROTATE_180;
-                        case COUNTERCLOCKWISE_90 -> flag |= MutableQuadView.BAKE_ROTATE_270;
-                    }
-
-                    emitter.spriteBake(texture, flag);
-                    emitter.color(-1, -1, -1, -1);
-                    emitter.emit();
-                }
-            }
+        WrappedGetter getter = new WrappedGetter(blockView);
+        for (Direction value : DIRECTIONS) {
+            emitQuads(context.getEmitter(), value, model.getQuads(getter, state, pos, value));
         }
     }
 
     @Override
-    public @NotNull List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction direction, RandomSource random) {
-        return List.of();
+    public void emitItemQuads(ItemStack stack, Supplier<RandomSource> randomSupplier, RenderContext context) {
+        for (var direction : DIRECTIONS) {
+            emitQuads(context.getEmitter(), direction, model.getDefaultQuads(direction).getOrDefault(direction, List.of()));
+        }
+    }
+
+    private void emitQuads(QuadEmitter emitter, @Nullable Direction side, List<AthenaQuad> quads) {
+        for (var sprite : quads) {
+            TextureAtlasSprite texture = this.textures.get(sprite.sprite());
+            if (texture == null) {
+                continue;
+            }
+            emitter.square(side, sprite.left(), sprite.bottom(), sprite.right(), sprite.top(), sprite.depth());
+
+            int flag = MutableQuadView.BAKE_LOCK_UV;
+
+            switch (sprite.rotation()) {
+                case CLOCKWISE_90 -> flag |= MutableQuadView.BAKE_ROTATE_90;
+                case CLOCKWISE_180 -> flag |= MutableQuadView.BAKE_ROTATE_180;
+                case COUNTERCLOCKWISE_90 -> flag |= MutableQuadView.BAKE_ROTATE_270;
+            }
+
+            emitter.spriteBake(texture, flag);
+            emitter.color(-1, -1, -1, -1);
+            emitter.emit();
+        }
+    }
+
+    private List<BakedQuad>[] createDefaultQuads() {
+        var renderer = RendererAccess.INSTANCE.getRenderer();
+        if (renderer == null) {
+            return new List[] { List.of(), List.of(), List.of(), List.of(), List.of(), List.of(), List.of() };
+        }
+        var meshBuilder = renderer.meshBuilder();
+
+        for (var direction : DIRECTIONS) {
+            emitQuads(meshBuilder.getEmitter(), direction, model.getDefaultQuads(direction).getOrDefault(direction, List.of()));
+        }
+
+        return ModelHelper.toQuadLists(meshBuilder.build());
+    }
+
+    @Override
+    public List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction direction, RandomSource random) {
+        var defaultQuads = this.defaultQuads;
+        if (defaultQuads == null) {
+            synchronized (this) {
+                if ((defaultQuads = this.defaultQuads) == null) {
+                    this.defaultQuads = defaultQuads = createDefaultQuads();
+                }
+            }
+        }
+
+        return defaultQuads[ModelHelper.toFaceIndex(direction)];
     }
 
     @Override


### PR DESCRIPTION
Uses default quads in item contexts (`emitItemQuads`) as well as non-FRAPI contexts (`getQuads`). Both are needed to correctly renderer Athena models used as a Modern Industrialization machine casing, for item display and multiblock previews respectively.